### PR TITLE
Change: the shebang in sofi

### DIFF
--- a/sofi
+++ b/sofi
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/env bash
 
 dir_cache=$HOME/.cache/sofi.cache
 


### PR DESCRIPTION
Changed the shebang from `bash -eu` to `env bash`!